### PR TITLE
Add binding for `tcbdbflags`

### DIFF
--- a/src/camltc.mli
+++ b/src/camltc.mli
@@ -30,6 +30,9 @@ module Bdb : sig
   val _tranbegin: bdb -> unit
   val _trancommit: bdb -> unit
   val _tranabort: bdb -> unit
+
+  type flag = BDBFOPEN | BDBFFATAL
+  val flags: bdb -> flag list
 end
 
 module Hotc : sig 

--- a/src/otc.ml
+++ b/src/otc.ml
@@ -189,4 +189,15 @@ module Bdb = struct
     with
       | Not_found -> []
 
+
+  external _flags : bdb -> int = "bdb_flags"
+  type flag = BDBFOPEN | BDBFFATAL
+
+  let flags bdb =
+    let f = _flags bdb in
+    List.fold_left
+      (fun acc (s, c) -> if f land c <> 0 then s :: acc else acc)
+      []
+      (* Shifts taken from tcbdb.h and tchdb.h *)
+      [(BDBFOPEN, 1 lsl 0); (BDBFFATAL, 1 lsl 1)]
 end

--- a/src/otc_test.ml
+++ b/src/otc_test.ml
@@ -89,6 +89,10 @@ let test_null db =
   let () = eq_int "char0" 0 (int_of_char str2.[4]) in
     ()
 
+let test_flags db =
+  match Bdb.flags db with
+    | [Bdb.BDBFOPEN] -> ()
+    | _ -> assert_failure "Unexpected flags set"
 
 let suite =
   let wrap f = bracket setup_tc f teardown_tc in
@@ -102,4 +106,5 @@ let suite =
       "unknown" >:: wrap test_unknown;
       "prefix_keys" >:: wrap test_prefix_keys;
       "null" >:: wrap test_null;
+      "flags" >:: wrap test_flags;
     ]

--- a/src/otc_wrapper.c
+++ b/src/otc_wrapper.c
@@ -473,3 +473,10 @@ void bdb_tune(value bdb, /* value lmemb, value nmemb, value bnum, value apow, va
 
   CAMLreturn0;
 }
+
+value bdb_flags(value bdb)
+{
+  CAMLparam1(bdb);
+  uint8_t flags = tcbdbflags(Bdb_val(bdb));
+  CAMLreturn(Val_int(flags));
+}


### PR DESCRIPTION
In order to implement [ARAKOON-393](http://jira.incubaid.com/browse/ARAKOON-393) this new binding is required.
