### PR TITLE
Rework `dbopen` modes

### DIFF
--- a/src/camltc.mli
+++ b/src/camltc.mli
@@ -8,10 +8,20 @@ val dependencies: string
 
 
 module Bdb : sig
+  module OpenMode : sig
+    type t = OREADER
+           | OWRITER
+           | OCREAT
+           | OTRUNC
+           | ONOLCK
+           | OLCKNB
+           | OTSYNC
+  end
+
   type bdb
   type bdbcur
-  val default_mode : int
-  val readonly_mode : int
+  val default_mode : OpenMode.t list
+  val readonly_mode : OpenMode.t list
   type opt = BDBTLARGE
   val put : bdb -> string -> string -> unit
   val get: bdb -> string -> string
@@ -63,7 +73,7 @@ module Hotc : sig
   type bdb = Bdb.bdb
   type bdbcur = Bdb.bdbcur
   val filename : t -> string
-  val create : ?mode:int ->
+  val create : ?mode:Bdb.OpenMode.t list ->
     ?lcnum:int ->
     ?ncnum:int ->
     string -> Bdb.opt list -> t Lwt.t
@@ -75,5 +85,5 @@ module Hotc : sig
   val defrag : ?step:int64 -> t -> int Lwt.t
   val sync :t -> unit Lwt.t
   val close : t -> unit Lwt.t
-  val reopen: t -> (unit -> unit Lwt.t) -> int -> unit Lwt.t
+  val reopen: t -> (unit -> unit Lwt.t) -> Bdb.OpenMode.t list -> unit Lwt.t
 end

--- a/src/hotc.ml
+++ b/src/hotc.ml
@@ -22,7 +22,7 @@ module Hotc = struct
       (fun e -> Lwt.fail e)
 
   let _open t mode =
-    Bdb._dbopen t.bdb t.filename mode
+    Bdb.dbopen t.bdb t.filename mode
 
   let _open_lwt t mode = Lwt.return (_open t mode )
 

--- a/src/hotc.mli
+++ b/src/hotc.mli
@@ -9,11 +9,11 @@ module Hotc : sig
   val batch : t -> int -> string -> string option -> (string * string) list Lwt.t
   val get_bdb : t -> bdb
   val read : t -> (bdb -> 'b Lwt.t) -> 'b Lwt.t
-  val create: ?mode:int -> ?lcnum:int -> ?ncnum:int ->
+  val create: ?mode:Otc.Bdb.OpenMode.t list -> ?lcnum:int -> ?ncnum:int ->
     string -> Otc.Bdb.opt list -> t Lwt.t
   val delete: t -> unit Lwt.t
   val optimize: t -> unit Lwt.t
-  val reopen: t -> (unit -> unit Lwt.t) -> int -> unit Lwt.t
+  val reopen: t -> (unit -> unit Lwt.t) -> Otc.Bdb.OpenMode.t list -> unit Lwt.t
   val sync : t -> unit Lwt.t
   val close : t -> unit Lwt.t
   val defrag : ?step:int64 -> t -> int Lwt.t

--- a/src/otc_test.ml
+++ b/src/otc_test.ml
@@ -5,7 +5,7 @@ open Extra
 
 let setup_tc _ =
   let db = Bdb._make () in
-  let _ = Bdb._dbopen db "/tmp/db1.tc" (Bdb.owriter lor Bdb.ocreat lor Bdb.otrunc) in
+  let _ = Bdb.dbopen db "/tmp/db1.tc" Bdb.OpenMode.([OWRITER; OCREAT; OTRUNC]) in
     db
 
 let teardown_tc db =


### PR DESCRIPTION
Whilst previously the `mode` argument passed to `_dbopen` was a plain
`int`, without the predefined flag values being exposed, this change
reworks this into using a list of a flag type.
