### PR TITLE
expose volatile buffer variants to get keys and values (avoiding 1 strin...

### DIFF
--- a/src/camltc.mli
+++ b/src/camltc.mli
@@ -15,6 +15,7 @@ module Bdb : sig
   type opt = BDBTLARGE
   val put : bdb -> string -> string -> unit
   val get: bdb -> string -> string
+  val get3: bdb -> string -> string
   val get_nolock : bdb -> string -> string
   val out: bdb -> string -> unit
   val range: bdb ->
@@ -60,6 +61,8 @@ module Bdb : sig
 
   val key: bdb -> bdbcur -> string
   val value: bdb -> bdbcur -> string
+  val key3: bdb -> bdbcur -> string
+  val value3: bdb -> bdbcur -> string
 
   val with_cursor : bdb -> (bdb -> bdbcur -> 'a) -> 'a
 

--- a/src/otc.ml
+++ b/src/otc.ml
@@ -44,6 +44,8 @@ module Bdb = struct
   external last: bdb -> bdbcur -> unit = "bdb_last"
   external key: bdb -> bdbcur -> string = "bdb_key"
   external value: bdb -> bdbcur -> string = "bdb_value"
+  external key3: bdb -> bdbcur -> string = "bdb_key3"
+  external value3: bdb -> bdbcur -> string = "bdb_value3"
   external record: bdb -> bdbcur -> string * string = "bdb_record"
   external jump: bdb -> bdbcur -> string -> unit = "bdb_jump"
 
@@ -57,6 +59,7 @@ module Bdb = struct
   external out: bdb -> string -> unit = "bdb_out"
   external put: bdb -> string -> string -> unit = "bdb_put"
   external get: bdb -> string -> string = "bdb_get"
+  external get3: bdb -> string -> string = "bdb_get3"
   external get_nolock : bdb -> string -> string = "bdb_get_nolock"
   external putkeep: bdb -> string -> string -> unit = "bdb_putkeep"
 

--- a/src/otc_wrapper.c
+++ b/src/otc_wrapper.c
@@ -231,6 +231,21 @@ value bdb_key(value bdb, value bdbcur)
   CAMLreturn(res);
 }
 
+value bdb_key3(value bdb, value bdbcur)
+{
+  CAMLparam2(bdb, bdbcur);
+  CAMLlocal1(res);
+
+  int len = 0;
+  const void *str =tcbdbcurkey3(Bdbcur_val(bdbcur),&len);
+  if (str == 0)
+    {
+      bdb_handle_error(Bdb_val(bdb));
+    }
+  res = caml_copy_string_with_length(str, len);
+  CAMLreturn(res);
+}
+
 value bdb_value(value bdb, value bdbcur)
 {
   CAMLparam2(bdb, bdbcur);
@@ -243,6 +258,20 @@ value bdb_value(value bdb, value bdbcur)
     }
   res = caml_copy_string_with_length(str, len);
   free(str);
+  CAMLreturn(res);
+}
+
+value bdb_value3(value bdb, value bdbcur)
+{
+  CAMLparam2(bdb, bdbcur);
+  CAMLlocal1(res);
+  int len = 0;
+  const void *str =tcbdbcurval3(Bdbcur_val(bdbcur), &len);
+  if (str == 0)
+    {
+      bdb_handle_error(Bdb_val(bdb));
+    }
+  res = caml_copy_string_with_length(str, len);
   CAMLreturn(res);
 }
 
@@ -330,6 +359,22 @@ value bdb_get(value bdb, value key)
     } else {
     res = caml_copy_string_with_length(v1, vlen);
     free(v1);
+  }
+  CAMLreturn(res);
+}
+
+value bdb_get3(value bdb, value key)
+{
+  CAMLparam2(bdb, key);
+  CAMLlocal1(res);
+  const int klen = caml_string_length(key);
+  int vlen;
+  const void * v1 = tcbdbget3(Bdb_val(bdb), String_val(key), klen, &vlen);
+  if (v1 == 0)
+    {
+      bdb_handle_error(Bdb_val(bdb));
+    } else {
+    res = caml_copy_string_with_length(v1, vlen);
   }
   CAMLreturn(res);
 }


### PR DESCRIPTION
...g copy)
