### PR TITLE
lwt_log instead of lwt.log

### DIFF
--- a/src/META
+++ b/src/META
@@ -1,6 +1,6 @@
 description = "camltc : ocaml bindings for tokyo cabinet"
 version = "0.9.4"
 exists_if = "camltc.cma,camltc.cmxa"
-requires = "unix, lwt, lwt.unix, lwt.log"
+requires = "unix, lwt, lwt.unix, lwt_log"
 archive(byte) = "camltc.cma"
 archive(native) = "camltc.cmxa"


### PR DESCRIPTION
required by recent versions of lwt I think