### PR TITLE
Fixed link for submulde tokyocabinet. 'git://' doesn't work anymore. …

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/3rd-party/tokyocabinet"]
 	path = src/3rd-party/tokyocabinet
-	url = git://github.com/Incubaid/tokyocabinet.git
+	url = https://github.com/Incubaid/tokyocabinet.git
 	branch = arakoon


### PR DESCRIPTION
…See https://github.blog/2021-09-01-improving-git-protocol-security-github/